### PR TITLE
Remove parens surrounding url in output

### DIFF
--- a/src/feed.rs
+++ b/src/feed.rs
@@ -334,7 +334,7 @@ impl Feed {
                 Ok(_) | Err(_) => self.base_url.join(&item.id)?,
             };
 
-            writeln!(stdout, " ({})", post_url.to_string())?;
+            writeln!(stdout, " {}", post_url.to_string())?;
             stdout.reset()?;
 
             idx += 1;


### PR DESCRIPTION
This solves an issue where terminals include the paren in their detected hyperlink. When you click the url, some sites won't be able to find the url because of the extra paren at the end. The paren at the front doesn't suffer from this.